### PR TITLE
Update github-script action to v6

### DIFF
--- a/.github/workflows/build-deploy-solution.yml
+++ b/.github/workflows/build-deploy-solution.yml
@@ -26,7 +26,7 @@ jobs:
       - if: contains(github.event.inputs.ref, 'refs/pull')
         name: update-commit-status
         id: update-commit-status
-        uses: actions/github-script@v5
+        uses: actions/github-script@v6
         env:
           CONTEXT_TO_USE: build-deploy-${{ github.event.inputs.solution_name }}
           SHA: ${{ github.event.inputs.sha }}
@@ -93,7 +93,7 @@ jobs:
       - if: contains(github.event.inputs.ref, 'refs/pull')
         name: update-commit-status
         id: update-commit-status
-        uses: actions/github-script@v5
+        uses: actions/github-script@v6
         env:
           CONTEXT_TO_USE: build-deploy-${{ github.event.inputs.solution_name }}
           SHA: ${{ github.event.inputs.sha }}

--- a/.github/workflows/determine-solution-build-deploy.yml
+++ b/.github/workflows/determine-solution-build-deploy.yml
@@ -61,7 +61,7 @@ jobs:
       - name: create-commit-statuses
         id: create-commit-statuses
         if: contains(github.ref, 'pull')
-        uses: actions/github-script@v5
+        uses: actions/github-script@v6
         with:
           script: |
             const createCommitStatuses = require('${{ env.workflow_scripts_path }}/js/createCommitStatuses.js')


### PR DESCRIPTION
### Describe the issue
When using the actions/github-script action, a deprecation warning is shown.

![imagen](https://user-images.githubusercontent.com/62261539/166244498-3468e0fe-e506-45ad-92cf-668ebb37d263.png)

### Changes included in the PR

- Updated the action version to v6.

### Screenshots

After updating the action's version the warning is not shown anymore.

![imagen](https://user-images.githubusercontent.com/62261539/166246376-23ec17a5-2a78-4f34-9df4-827d63c2da17.png)
